### PR TITLE
Fixed hyperlink mistakes on homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 - Hyperlinks on `pages/details_for_registration.html` need to link to the registration page
 - A not-so-sharp color for Table Caption "Important Note"
 
+## 2021-01-30 15:00 [Trevor]
+### `index.html`
+#### Added
+- Hyperlink to `pages/details_for_registration.html` in menu bar
+#### Fixed
+- Hyperlink to `pages/ethics_biosafety_and_biosecurity.html` in menu bar
+
 ## 2021-01-30 14:50 [Trevor]
 
 ### `css/style.css`

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style="color: #4B0082;"> Registration </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-              <a class="dropdown-item" href="#" style="color: #2a206a;">Details you need</a>
+              <a class="dropdown-item" href="pages/details_for_registration.html" style="color: #2a206a;">Details you need</a>
               <div class="dropdown-divider"></div>
               <a class="dropdown-item" href="#" style="color: #2a206a;">Register for iDEC 2021</a>
             </div>
@@ -47,7 +47,7 @@
 		  <li class="nav-item"> <a class="nav-link" href="https://idec-wiki.herokuapp.com/" style="color: #2a206a;">Resources</a> </li>
 		  <li class="nav-item"> <a class="nav-link" href="pages/tracks_and_awards.html" style="color: #2a206a;">Tracks and awards</a> </li>
       <li class="nav-item"> <a class="nav-link" href="pages/requirements.html" style="color: #2a206a;">Requirements</a> </li>
-      <li class="nav-item"> <a class="nav-link" href="ethics_biosafety_and_biosecurity.html" style="color: #2a206a;">Ethics, Biosafety and Biosecurity</a> </li>
+      <li class="nav-item"> <a class="nav-link" href="pages/ethics_biosafety_and_biosecurity.html" style="color: #2a206a;">Ethics, Biosafety and Biosecurity</a> </li>
         </ul>
         <form class="form-inline my-2 my-lg-0">
           <input class="form-control mr-sm-2" type="search" placeholder="Search" aria-label="Search">


### PR DESCRIPTION
## 2021-01-30 15:00 [Trevor]
### `index.html`
#### Added
- Hyperlink to `pages/details_for_registration.html` in menu bar
#### Fixed
- Hyperlink to `pages/ethics_biosafety_and_biosecurity.html` in menu bar